### PR TITLE
hashtable fix bug on find, tests

### DIFF
--- a/javascript/code-challenges/hashtable/hashtable.js
+++ b/javascript/code-challenges/hashtable/hashtable.js
@@ -25,7 +25,7 @@ class Bucket {
     for(let i=0; i<this.list.length; i++) {
       const [k, v] = this.list[i];
       if(k===key) {
-        return this.list[i];
+        return v;
       }
     }
     return null;
@@ -58,11 +58,16 @@ class Hashtable {
     const hashKey = this.hash(key);
     const bucket = this.arr[hashKey];
     if(bucket) {
-      const [_key, value] = bucket.find(key);
+      const value = bucket.find(key);
       return value;
     } else {
       return null;
     }
+  }
+
+  has(key) {
+    const value = this.get(key);
+    return Boolean(value);
   }
 }
 

--- a/javascript/code-challenges/hashtable/hashtable.test.js
+++ b/javascript/code-challenges/hashtable/hashtable.test.js
@@ -17,11 +17,63 @@ describe('Hashtable', () => {
   
   test('should set/get several similar element into the hash table', () => {
     const hash = new Hashtable();
+
     hash.set('elephant', {name: 'Elly'});
     hash.set('elephants', [{name: 'Elly'}, {name: 'Ella'}]);
+
     hash.set('eagle', {name: 'Eagle Eye'});
     hash.set('eel', {name: 'Electra'});
     hash.set('aardvark', {name: 'Arthur'});
+    hash.set('ant', {name: 'Betsy'})
+    expect(hash.get('eel')).toEqual({name: 'Electra'});
+    expect(hash.get('aardvark')).toEqual({name: 'Arthur'});
+    expect(hash.get('ant')).toEqual({name: 'Betsy'});
+
+  });
+
+  test('has should return false if element does not exist, true otherwise', () => {
+    const hash = new Hashtable();
+
+    expect(hash.has('elephant')).toBe(false);
+    hash.set('elephant', {name: 'Elly'});
+    expect(hash.has('elephant')).toBe(true);
+
+    expect(hash.has('elephants')).toBe(false);
+    hash.set('elephants', [{name: 'Elly'}, {name: 'Ella'}]);
+    expect(hash.has('elephants')).toBe(true);
+    
+    expect(hash.has('eagle')).toBe(false);
+    hash.set('eagle', {name: 'Eagle Eye'});
+    expect(hash.has('eagle')).toBe(true);
+
+    expect(hash.has('eel')).toBe(false);
+    hash.set('eel', {name: 'Electra'});
+    expect(hash.has('eel')).toBe(true);
+
+    expect(hash.has('aardvark')).toBe(false);
+    hash.set('aardvark', {name: 'Arthur'});
+    expect(hash.has('aardvark')).toBe(true);
+
+    expect(hash.has('ant')).toBe(false);
+    hash.set('ant', {name: 'Betsy'})
+    expect(hash.has('ant')).toBe(true);
+
+  });
+
+  test('should return null if element does not exist', () => {
+    const hash = new Hashtable();
+    expect(hash.get('elephant')).toBe(null);
+    expect(hash.has('elephant')).toBe(false);
+    hash.set('elephant', {name: 'Elly'});
+    expect(hash.get('elephants')).toBe(null);
+    hash.set('elephants', [{name: 'Elly'}, {name: 'Ella'}]);
+    expect(hash.get('eagle')).toBe(null);
+    hash.set('eagle', {name: 'Eagle Eye'});
+    expect(hash.get('eel')).toBe(null);
+    hash.set('eel', {name: 'Electra'});
+    expect(hash.get('aardvark')).toBe(null);
+    hash.set('aardvark', {name: 'Arthur'});
+    expect(hash.get('ant')).toBe(null);
     hash.set('ant', {name: 'Betsy'})
     expect(hash.get('eel')).toEqual({name: 'Electra'});
     expect(hash.get('ant')).toEqual({name: 'Betsy'});


### PR DESCRIPTION
- [x] has method
- [x] more tests
- [x] fixes bug where `find` throws exception when searching for a missing key when the bucket is non-empty  